### PR TITLE
Fix incorrect gemspec.

### DIFF
--- a/actionwebservice.gemspec
+++ b/actionwebservice.gemspec
@@ -10,10 +10,10 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "aws"
   s.homepage = "http://www.rubyonrails.org"
 
-  s.add_dependency('actionpack', '= 2.3.5')
-  s.add_dependency('activerecord', '= 2.3.5')
+  s.add_dependency 'actionpack', '3.0.0.rc2'
+  s.add_dependency 'activerecord', '3.0.0.rc2'
+  s.add_dependency 'activesupport', '3.0.0.rc2'
 
-  
   s.has_rdoc = true
   s.requirements << 'none'
   s.require_path = 'lib'

--- a/lib/action_web_service.rb
+++ b/lib/action_web_service.rb
@@ -31,7 +31,6 @@ begin
   require 'action_dispatch/routing'
 rescue LoadError
   require 'rubygems'
-  gem 'activesupport', '3.0.0.rc2'
   gem 'actionpack', '3.0.0.rc2'
   gem 'activerecord', '3.0.0.rc2'
   gem 'activesupport', '3.0.0.rc2'


### PR DESCRIPTION
This gemspec is incorrect, it points to 2.3.x versions of rails libs. Fixed so
it matches the 3.0.x version in lib/AWS.
